### PR TITLE
Topic/leading slack shipments

### DIFF
--- a/finale.gemspec
+++ b/finale.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
-  spec.files         = Dir['CHANGELOG.md', 'README.md', 'LICENSE', 'lib/**/*']
+  spec.files         = Dir['CHANGELOG.md', 'README.md', 'LICENSE', 'lib/**/*', 'spec/test_support.rb', 'spec/client_mock.rb', 'spec/factories/**/*']
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/finale.gemspec
+++ b/finale.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "json", "~> 1.8"
   spec.add_runtime_dependency "rest-client", "~> 2.0"
-  spec.add_runtime_dependency "activesupport", "~> 4.2.0"
+  spec.add_runtime_dependency "activesupport", "~> 4.2"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "webmock", "~> 3.4"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency 'pry-byebug', '~> 3'
-  spec.add_development_dependency "factory_bot", "~> 4.10.0"
+  spec.add_development_dependency "factory_bot", "~> 4.10"
   spec.add_development_dependency "simplecov", "~> 0.16"
 end

--- a/lib/finale.rb
+++ b/lib/finale.rb
@@ -1,2 +1,10 @@
-require "finale/version"
-require "finale/client"
+require 'finale/version'
+require 'finale/client'
+require_relative '../spec/test_support'
+require_relative '../spec/client_mock'
+
+module Finale
+  def self.root
+    @root ||= Pathname.new(File.dirname(File.expand_path(File.dirname(__FILE__), '/../')))
+  end
+end

--- a/lib/finale/facility.rb
+++ b/lib/finale/facility.rb
@@ -1,0 +1,4 @@
+module Finale
+  class Facility < OpenStruct
+  end
+end

--- a/lib/finale/shipment.rb
+++ b/lib/finale/shipment.rb
@@ -9,4 +9,3 @@ module Finale
     end
   end
 end
-

--- a/lib/finale/shipment_item.rb
+++ b/lib/finale/shipment_item.rb
@@ -1,5 +1,9 @@
+require_relative 'uri_helper'
+
 module Finale
   class ShipmentItem
+    include URIHelper
+
     def initialize(product_id: , facility_id: , quantity: , lot_id: nil)
       @product_id = product_id
       @facility_id = facility_id
@@ -9,8 +13,8 @@ module Finale
 
     def format_for_post(account)
       {
-        productUrl: account + "/api/product/#{@product_id}",
-        facilityUrl: account + "/api/facility/#{@facility_id}",
+        productUrl: resource_path(:product, account: account, id: @product_id),
+        facilityUrl: resource_path(:facility, account: account, id: @facility_id),
         quantity: @quantity,
         lotId: @lot_id&.rjust(12, 'L_') # L_F0137A3-U0
       }.compact

--- a/lib/finale/shipment_item.rb
+++ b/lib/finale/shipment_item.rb
@@ -14,7 +14,7 @@ module Finale
     def format_for_post(account)
       {
         productUrl: resource_path(:product, account: account, id: @product_id),
-        facilityUrl: resource_path(:facility, account: account, id: @facility_id),
+        facilityUrl: resource_path(:facility, account: account, id: @facility_id, leading_slash: true),
         quantity: @quantity,
         lotId: @lot_id&.rjust(12, 'L_') # L_F0137A3-U0
       }.compact

--- a/lib/finale/shipment_item.rb
+++ b/lib/finale/shipment_item.rb
@@ -1,0 +1,19 @@
+module Finale
+  class ShipmentItem
+    def initialize(product_id: , facility_id: , quantity: , lot_id: nil)
+      @product_id = product_id
+      @facility_id = facility_id
+      @quantity = quantity
+      @lot_id = lot_id
+    end
+
+    def format_for_post(account)
+      {
+        productUrl: account + "/api/product/#{@product_id}",
+        facilityUrl: account + "/api/facility/#{@facility_id}",
+        quantity: @quantity,
+        lotId: @lot_id&.rjust(12, 'L_') # L_F0137A3-U0
+      }.compact
+    end
+  end
+end

--- a/lib/finale/uri_helper.rb
+++ b/lib/finale/uri_helper.rb
@@ -1,0 +1,18 @@
+module Finale
+  module URIHelper
+    BASE_URL = 'https://app.finaleinventory.com'
+
+    def url(resource, url_base: BASE_URL, account: @account, id: nil, action: nil)
+      resource_path = resource_path(resource, account: account, id: id, action: action)
+      url_from_path(resource_path, url_base: url_base)
+    end
+
+    def url_from_path(resource_path, url_base: BASE_URL)
+      "#{url_base}/#{resource_path}"
+    end
+
+    def resource_path(resource, account: @account, id: nil, action: nil)
+      [account, 'api', resource, id, action].compact.join('/')
+    end
+  end
+end

--- a/lib/finale/uri_helper.rb
+++ b/lib/finale/uri_helper.rb
@@ -11,8 +11,10 @@ module Finale
       "#{url_base}/#{resource_path}"
     end
 
-    def resource_path(resource, account: @account, id: nil, action: nil)
-      [account, 'api', resource, id, action].compact.join('/')
+    def resource_path(resource, account: @account, id: nil, action: nil, leading_slash: false)
+      path = [account, 'api', resource, id, action].compact.join('/')
+      path = leading_slash ? "/#{path}" : path
+      path
     end
   end
 end

--- a/lib/finale/version.rb
+++ b/lib/finale/version.rb
@@ -1,3 +1,3 @@
 module Finale
-  VERSION = '0.2.1'
+  VERSION = '0.2.3'
 end

--- a/lib/finale/version.rb
+++ b/lib/finale/version.rb
@@ -1,3 +1,3 @@
 module Finale
-  VERSION = "0.1.10"
+  VERSION = "0.2.0"
 end

--- a/lib/finale/version.rb
+++ b/lib/finale/version.rb
@@ -1,3 +1,3 @@
 module Finale
-  VERSION = "0.2.0"
+  VERSION = '0.2.1'
 end

--- a/spec/client_mock.rb
+++ b/spec/client_mock.rb
@@ -1,0 +1,78 @@
+module Finale
+  class ClientMock < Client
+    def initialize(account: nil, throttle_mode: false)
+      @stubbed_responses = {}
+      super
+    end
+
+    def login(username: nil, password: nil)
+      @cookies = { 'JSESSIONID' => '123' }
+    end
+
+    def stub_responses(method_name, value)
+      @stubbed_responses.merge!(method_name.to_sym => value)
+    end
+
+    def get_shipment(id)
+      verify_login
+      get_stubbed_response(:get_shipment) || FactoryBot.build(:finale_shipment, options: { id: id })
+    end
+
+    def get_order(id)
+      verify_login
+      get_stubbed_response(:get_order) || FactoryBot.build(:finale_order, options: { id: id })
+    end
+
+    def get_orders(filter: {}, order_type_id: nil, last_updated_date: nil)
+      # Doesn't respect params
+      verify_login
+      get_stubbed_response(:get_orders) || [ FactoryBot.build(:finale_order), FactoryBot.build(:finale_order) ]
+    end
+
+    def get_shipments(filter: {}, shipment_type_id: nil, last_updated_date: nil)
+      # Doesn't respect params
+      verify_login
+      get_stubbed_response(:get_shipments) || [ FactoryBot.build(:finale_shipment), FactoryBot.build(:finale_shipment) ]
+    end
+
+    def get_order_from_shipment(shipment)
+      verify_login
+      get_stubbed_response(:get_order_from_shipment) || FactoryBot.build(:finale_order, options: { id: shipment.order_id, shipment_id1: shipment.shipmentId })
+    end
+
+    def get_shipments_from_order(order)
+      verify_login
+      get_stubbed_response(:get_shipments_from_order) || [ FactoryBot.build(:finale_shipment, options: { order_id: order.orderId }) ]
+    end
+
+    def get_facilities
+      verify_login
+      get_stubbed_response(:get_facilities) || [ FactoryBot.build(:finale_facility), FactoryBot.build(:finale_facility) ]
+    end
+
+    def create_shipment_for_order(order_id, items)
+      shipment_items = items.map { |item| item.format_for_post(@account) }
+      verify_login
+      get_stubbed_response(:create_shipment_for_order) || FactoryBot.build(:finale_shipment, options: { shipment_item_list: shipment_items })
+    end
+
+    def pack_shipment(shipment)
+      verify_login
+      shipment
+    end
+
+    private
+
+    def verify_login
+      raise NotLoggedIn.new(verb: '_', url: '_') unless @cookies&.dig('JSESSIONID').present?
+    end
+
+    def get_stubbed_response(method_name)
+      @stubbed_responses[method_name]
+    end
+
+    def request(verb: nil, url: nil, payload: nil, filter: nil)
+      puts "Warning: ClientMock missing method implementation. Blocking request to #{verb}: #{url}"
+    end
+  end
+end

--- a/spec/factories/facilities.rb
+++ b/spec/factories/facilities.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :finale_facility, class: Finale::Facility do
+    transient do
+      options { {} }
+    end
+
+    response { build(:finale_facility_response, **options) }
+
+    initialize_with do
+      new(response)
+    end
+  end
+end

--- a/spec/factories/facility_responses.rb
+++ b/spec/factories/facility_responses.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
-  factory :facility_response, class: Hash do
-    id      { '10001' }
-    account { 'some_account' }
+  factory :finale_facility_response, class: Hash do
+    sequence(:id, 10001)       { |n| n.to_s }
+    sequence(:facilityName, 1) { |n| "Warehouse #{n}" }
+    account                    { 'some_account' }
 
     initialize_with do
       {
@@ -20,7 +21,7 @@ FactoryBot.define do
           postalCode: '12345',
           countryGeoId: 'USA'
         },
-        facilityName: 'A Warehouse',
+        facilityName: facilityName,
         parentFacilityUrl: "/#{account}/api/facility/10000",
         shippingDisabled: nil,
         actionUrlActivate: nil,
@@ -29,7 +30,7 @@ FactoryBot.define do
     end
   end
 
-  factory :facility_collection, class: Hash do
+  factory :finale_facility_collection, class: Hash do
     account      { 'some_account' }
     facility_id1 { '10000' }
     facility_id2 { '10001' }
@@ -66,4 +67,3 @@ FactoryBot.define do
     end
   end
 end
-

--- a/spec/factories/facility_responses.rb
+++ b/spec/factories/facility_responses.rb
@@ -1,0 +1,69 @@
+FactoryBot.define do
+  factory :facility_response, class: Hash do
+    id      { '10001' }
+    account { 'some_account' }
+
+    initialize_with do
+      {
+        facilityId: id,
+        facilityUrl: "/#{account}/api/facility/#{id}",
+        statusId: 'FACILITY_ACTIVE',
+        lastUpdatedDate: '2018-07-30T17:57:29',
+        createdDate: '2018-07-30T17:56:59',
+        actionUrlDeactivate: "/#{account}/api/facility/#{id}/deactivate",
+        contactMech: {
+          contactMechId: '10093',
+          contactMechTypeId: 'POSTAL_ADDRESS',
+          address1: '123 Main St',
+          city: 'Denver',
+          stateProvinceGeoId: 'CO',
+          postalCode: '12345',
+          countryGeoId: 'USA'
+        },
+        facilityName: 'A Warehouse',
+        parentFacilityUrl: "/#{account}/api/facility/10000",
+        shippingDisabled: nil,
+        actionUrlActivate: nil,
+        receivingDisabled: nil
+      }
+    end
+  end
+
+  factory :facility_collection, class: Hash do
+    account      { 'some_account' }
+    facility_id1 { '10000' }
+    facility_id2 { '10001' }
+
+    initialize_with do
+      {
+        facilityId: [facility_id1, facility_id2],
+        facilityUrl: ["/#{account}/api/facility/#{facility_id1}", "/#{account}/api/facility/#{facility_id2}"],
+        statusId: ['FACILITY_ACTIVE', 'FACILITY_ACTIVE'],
+        lastUpdatedDate: ['2018-07-19T14:51:20', '2018-07-20T14:51:20'],
+        createdDate: ['2017-07-19T14:51:20', '2017-07-20T14:51:20'],
+        actionUrlDeactivate: ["/#{account}/api/facility/#{facility_id1}/deactivate", "/#{account}/api/facility/#{facility_id2}/deactivate"],
+        contactMech: [
+          {
+            contactMechId: '10093',
+            contactMechTypeId: 'POSTAL_ADDRESS',
+            address1: '123 Main St',
+            city: 'Denver',
+            stateProvinceGeoId: 'CO',
+            postalCode: '12345',
+            countryGeoId: 'USA'
+          },
+          {
+            contactMechId: '10094',
+            contactMechTypeId: 'POSTAL_ADDRESS'
+          }
+        ],
+        facilityName: ['The Main Warehouse', 'A Warehouse'],
+        parentFacilityUrl: [nil, "/#{account}/api/facility/10000"],
+        shippingDisabled: [nil, true],
+        actionUrlActivate: [nil, nil],
+        receivingDisabled: [nil, true]
+      }
+    end
+  end
+end
+

--- a/spec/factories/login_responses.rb
+++ b/spec/factories/login_responses.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :login_response, class: Hash do
+  factory :finale_login_response, class: Hash do
     initialize_with do
       {
         name: "some_user@some_account.com",
@@ -8,4 +8,3 @@ FactoryBot.define do
     end
   end
 end
-

--- a/spec/factories/order_responses.rb
+++ b/spec/factories/order_responses.rb
@@ -1,37 +1,41 @@
 FactoryBot.define do
-  factory :order_response, class: Hash do
-    id           { '10012' }
-    shipment_id1 { '10022' }
-    shipment_id2 { '10023' }
+  factory :finale_order_response, class: Hash do
+    sequence(:id, 1000) { |n| n.to_s }
+    saleSourceId        { 'some_source_id' }
+    account             { 'some_account' }
+    transient do
+      sequence(:shipment_id1, 1000) { |n| n.to_s }
+      sequence(:shipment_id2, 2000) { |n| n.to_s }
+    end
 
     initialize_with do
       {
         orderId: id,
-        orderUrl: "/demo/api/order/#{id}",
+        orderUrl: "/#{account}/api/order/#{id}",
         orderTypeId: 'SALES_ORDER',
-        orderHistoryListUrl: "/demo/api/order/#{id}/history/",
-        saleSourceId: 'some_source_id',
-        actionUrlLock: "/demo/api/order/#{id}/lock",
-        actionUrlComplete: "/demo/api/order/#{id}/complete",
-        actionUrlCancel: "/demo/api/order/#{id}/cancel",
-        reserveAllUrl: "/demo/api/order/#{id}/reserveall",
+        orderHistoryListUrl: "/#{account}/api/order/#{id}/history/",
+        saleSourceId: saleSourceId,
+        actionUrlLock: "/#{account}/api/order/#{id}/lock",
+        actionUrlComplete: "/#{account}/api/order/#{id}/complete",
+        actionUrlCancel: "/#{account}/api/order/#{id}/cancel",
+        reserveAllUrl: "/#{account}/api/order/#{id}/reserveall",
         statusId: 'ORDER_CREATED',
-        originFacilityUrl: '/demo/api/facility/10000',
+        originFacilityUrl: "/#{account}/api/facility/10000",
         orderItemList:  [
           {
-            orderItemUrl: "/demo/api/order/#{id}/orderItem/00000001",
-            reserveUrl: "/demo/api/order/#{id}/orderItem/00000001/reserve",
+            orderItemUrl: "/#{account}/api/order/#{id}/orderItem/00000001",
+            reserveUrl: "/#{account}/api/order/#{id}/orderItem/00000001/reserve",
             productId: 'BP2905',
-            productUrl: '/demo/api/product/BP2905',
+            productUrl: "/#{account}/api/product/BP2905",
             unitListPrice: 16.56,
             unitPrice: 16.56,
             quantity: 4
           },
           {
-            orderItemUrl: "/demo/api/order/#{id}/orderItem/00000002",
-            reserveUrl: "/demo/api/order/#{id}/orderItem/00000002/reserve",
+            orderItemUrl: "/#{account}/api/order/#{id}/orderItem/00000002",
+            reserveUrl: "/#{account}/api/order/#{id}/orderItem/00000002/reserve",
             productId: 'PH-1361',
-            productUrl: '/demo/api/product/PH-1361',
+            productUrl: "/#{account}/api/product/PH-1361",
             unitListPrice: 466.52,
             unitPrice: 466.52,
             normalizedPackingString: '36 cs 36/1',
@@ -40,12 +44,12 @@ FactoryBot.define do
         ],
         orderAdjustmentList: [],
         orderRoleList: [],
-        shipmentUrlList: ["/demo/api/shipment/#{shipment_id1}","/demo/api/shipment/#{shipment_id2}"]
+        shipmentUrlList: ["/#{account}/api/shipment/#{shipment_id1}","/#{account}/api/shipment/#{shipment_id2}"]
       }
     end
   end
 
-  factory :order_collection, class: Hash do
+  factory :finale_order_collection, class: Hash do
     account   { 'some_account' }
     order_id1 { '10012' }
     order_id2 { '10013' }
@@ -59,19 +63,19 @@ FactoryBot.define do
         originFacilityUrl: ["/#{account}/api/facility/200", "/#{account}/api/facility/200"],
         orderItemList: [
           [{
-            orderItemUrl: "/demo/api/order/#{order_id1}/orderItem/00000001",
-            reserveUrl: "/demo/api/order/#{order_id1}/orderItem/00000001/reserve",
+            orderItemUrl: "/#{account}/api/order/#{order_id1}/orderItem/00000001",
+            reserveUrl: "/#{account}/api/order/#{order_id1}/orderItem/00000001/reserve",
             productId: 'BP2905',
-            productUrl: '/demo/api/product/BP2905',
+            productUrl: "/#{account}/api/product/BP2905",
             unitListPrice: 16.56,
             unitPrice: 16.56,
             quantity: 4
           }],
           [{
-            orderItemUrl: "/demo/api/order/#{order_id2}/orderItem/00000002",
-            reserveUrl: "/demo/api/order/#{order_id2}/orderItem/00000002/reserve",
+            orderItemUrl: "/#{account}/api/order/#{order_id2}/orderItem/00000002",
+            reserveUrl: "/#{account}/api/order/#{order_id2}/orderItem/00000002/reserve",
             productId: 'PH-1361',
-            productUrl: '/demo/api/product/PH-1361',
+            productUrl: "/#{account}/api/product/PH-1361",
             unitListPrice: 466.52,
             unitPrice: 466.52,
             normalizedPackingString: '36 cs 36/1',
@@ -81,8 +85,8 @@ FactoryBot.define do
         orderAdjustmentList: [[], []],
         orderRoleList: [[], []],
         shipmentUrlList: [
-          ['/demo/api/shipment/shipment_id1','/demo/api/shipment/shipment_id2'],
-          ['/demo/api/shipment/shipment_id3','/demo/api/shipment/shipment_id4'],
+          ["/#{account}/api/shipment/shipment_id1", "/#{account}/api/shipment/shipment_id2"],
+          ["/#{account}/api/shipment/shipment_id3", "/#{account}/api/shipment/shipment_id4"],
         ],
         saleSourceId: ['SomeSource1', 'SomeSource2'],
         lastUpdatedDate: ['2018-07-19T14:51:20', '2018-07-20T14:51:20'],
@@ -104,4 +108,3 @@ FactoryBot.define do
     end
   end
 end
-

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,12 +1,13 @@
 FactoryBot.define do
-  factory :order, class: Finale::Order do
-    transient { shipment_id1 { '10001' } }
-    transient { shipment_id2 { '10002' } }
-    order_response { build(:order_response, shipment_id1: shipment_id1, shipment_id2: shipment_id2) }
+  factory :finale_order, class: Finale::Order do
+    transient do
+      options { {} }
+    end
+
+    order_response { build(:finale_order_response, **options) }
 
     initialize_with do
       new(order_response)
     end
   end
 end
-

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     order_response { build(:order_response, shipment_id1: shipment_id1, shipment_id2: shipment_id2) }
 
     initialize_with do
-     new(order_response)
+      new(order_response)
     end
   end
 end

--- a/spec/factories/shipment_item.rb
+++ b/spec/factories/shipment_item.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :shipment_item, class: Finale::ShipmentItem do
+    product_id { 'some_product_id' }
+    facility_id { 10001 }
+    quantity { 1 }
+    lot_id { 'L_F0BBBBB-U0' }
+
+    initialize_with do
+      new(product_id: product_id, facility_id: facility_id, quantity: quantity, lot_id: lot_id)
+    end
+  end
+end

--- a/spec/factories/shipment_item.rb
+++ b/spec/factories/shipment_item.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
-  factory :shipment_item, class: Finale::ShipmentItem do
-    product_id { 'some_product_id' }
+  factory :finale_shipment_item, class: Finale::ShipmentItem do
+    product_id  { 'some_product_id' }
     facility_id { 10001 }
-    quantity { 1 }
-    lot_id { 'L_F0BBBBB-U0' }
+    quantity    { 1 }
+    lot_id      { 'L_F0BBBBB-U0' }
 
     initialize_with do
       new(product_id: product_id, facility_id: facility_id, quantity: quantity, lot_id: lot_id)

--- a/spec/factories/shipment_responses.rb
+++ b/spec/factories/shipment_responses.rb
@@ -1,27 +1,29 @@
 FactoryBot.define do
-  factory :shipment_response, class: Hash do
-    id       { '11069' }
-    account  { 'some_account' }
-    order_id { '44444' }
+  factory :finale_shipment_response, class: Hash do
+    sequence(:id, 1000)           { |n| n.to_s }
+    sequence(:trackingCode, 1000) { |n| "6129098548342000#{n}" }
+    account                       { 'some_account' }
+    statusId                      { 'SHIPMENT_SHIPPED' }
+    cancelDate                    { nil }
     shipment_item_list {[
       {
         lotId: lot_id1,
         facilityUrl: "/#{account}/api/facility/10022",
-        productId: "some_product_id",
         productUrl: "/#{account}/api/product/some_product_id",
         quantity: 1
       },
       {
         lotId: lot_id2,
         facilityUrl: "/#{account}/api/facility/10022",
-        productId: "some_product_id",
         productUrl: "/#{account}/api/product/some_product_id",
         quantity: 1
       }
     ]}
-
-    transient { lot_id1  { 'L_F0BBBBB-U0' } }
-    transient { lot_id2  { 'L_F00CCCC-U0' } }
+    transient do
+      sequence(:lot_id1, 1000)  { |n| "L_F11#{n}-U0" }
+      sequence(:lot_id2, 1000)  { |n| "L_F22#{n}-U0" }
+      sequence(:order_id, 1000) { |n| n.to_s }
+    end
 
     initialize_with do
       {
@@ -32,25 +34,36 @@ FactoryBot.define do
         actionUrlCancel: "/#{account}/api/shipment/#{id}/cancel",
         actionUrlPack: "/#{account}/api/shipment/#{id}/pack",
         actionUrlUnpack: "/#{account}/api/shipment/#{id}/unpack",
+        actionUrlReceive: "/#{account}/api/shipment/#{id}/receive",
         actionUrlShip: "/#{account}/api/shipment/#{id}/ship",
         actionUrlTransfer: "/#{account}/api/shipment/#{id}/transfer",
         primaryOrderUrl: "/#{account}/api/order/#{order_id}",
-        statusId: "SHIPMENT_SHIPPED",
+        primaryReturnUrl: nil,
+        carrierPartyUrl: nil,
+        destinationFacilityUrl: nil,
+        originFacilityUrl: nil,
+        statusId: statusId,
         packDate: "2016-09-26T18:00:00",
         shipDate: "2016-09-26T18:00:00",
+        shipDateEstimated: "2016-09-26T18:00:00",
+        receiveDate: nil,
+        receiveDateEstimated: nil,
+        cancelDate: cancelDate,
         lastUpdatedDate: "2018-07-30T17:57:29",
         createdDate: "2018-07-30T17:56:59",
         facilityUrlPack: "/#{account}/api/facility/10022",
         userFieldDataList: [],
         shipmentItemList: shipment_item_list,
+        trackingCode: trackingCode,
         contentList: [],
+        countPackages: nil,
         transferList: [],
         statusIdHistoryList: []
       }
     end
   end
 
-  factory :shipment_collection, class: Hash do
+  factory :finale_shipment_collection, class: Hash do
     account      { 'some_account' }
     order_id     { '11111' }
     shipment_id1 { '22222' }
@@ -62,10 +75,18 @@ FactoryBot.define do
         shipmentIdUser: ["some_shipment_user_id-1", "some_shipment_user_id-2"],
         shipmentUrl: ["/#{account}/api/shipment/#{shipment_id1}", "/#{account}/api/shipment/#{shipment_id2}"],
         shipmentTypeId: ["SALES_SHIPMENT", "SALES_SHIPMENT"],
+        actionUrlCancel: ["/#{account}/api/shipment/#{shipment_id1}/cancel", "/#{account}/api/shipment/#{shipment_id2}/cancel"],
+        actionUrlPack: ["/#{account}/api/shipment/#{shipment_id1}/pack", "/#{account}/api/shipment/#{shipment_id2}/pack"],
+        actionUrlUnpack: ["/#{account}/api/shipment/#{shipment_id1}/unpack", "/#{account}/api/shipment/#{shipment_id2}/unpack"],
+        actionUrlReceive: ["/#{account}/api/shipment/#{shipment_id1}/receive", "/#{account}/api/shipment/#{shipment_id2}/receive"],
+        actionUrlShip: ["/#{account}/api/shipment/#{shipment_id1}/ship", "/#{account}/api/shipment/#{shipment_id2}/ship"],
+        actionUrlTransfer: ["/#{account}/api/shipment/#{shipment_id1}/transfer", "/#{account}/api/shipment/#{shipment_id2}/transfer"],
         primaryOrderUrl: ["/#{account}/api/order/#{order_id}", "/#{account}/api/order/#{order_id}"],
+        carrierPartyUrl: [nil, nil],
         statusId: ["SHIPMENT_SHIPPED", "SHIPMENT_SHIPPED"],
         packDate: ["2016-09-26T18:00:00", "2016-09-26T18:00:00"],
         shipDate: ["2016-09-26T18:00:00", "2016-09-26T18:00:00"],
+        cancelDate: [nil, "2016-09-27T01:00:00"],
         userFieldDataList: [],
         shipmentItemList: [
           [{
@@ -98,9 +119,8 @@ FactoryBot.define do
         countPackages: [1, 1],
         trackingCode: ['some_tracking_code_1', 'some_tracking_code_2'],
         shipDateEstimated: ["2016-09-26T18:00:00", "2016-09-26T18:00:00"],
-        externalUrl: [nil, nil],
+        externalUrl: [nil, nil]
       }
     end
   end
 end
-

--- a/spec/factories/shipments.rb
+++ b/spec/factories/shipments.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     end
 
     initialize_with do
-     new(shipment_response)
+      new(shipment_response)
     end
   end
 end

--- a/spec/factories/shipments.rb
+++ b/spec/factories/shipments.rb
@@ -1,14 +1,13 @@
 FactoryBot.define do
-  factory :shipment, class: Finale::Shipment do
-    shipment_response { build(:shipment_response, order_id: order_id) }
-
+  factory :finale_shipment, class: Finale::Shipment do
     transient do
-      order_id { '11111' }
+      options { {} }
     end
+
+    shipment_response { build(:finale_shipment_response, **options) }
 
     initialize_with do
       new(shipment_response)
     end
   end
 end
-

--- a/spec/finale/client_mock_spec.rb
+++ b/spec/finale/client_mock_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 RSpec.describe Finale::ClientMock do
   let(:client) { Finale::ClientMock.new(account: 'some_account') }

--- a/spec/finale/client_mock_spec.rb
+++ b/spec/finale/client_mock_spec.rb
@@ -1,0 +1,201 @@
+require 'spec_helper'
+require 'pry'
+
+RSpec.describe Finale::ClientMock do
+  let(:client) { Finale::ClientMock.new(account: 'some_account') }
+
+  describe '#login' do
+    subject { client.login(username: 'username', password: 'password') }
+
+    it { expect{subject}.to_not raise_error }
+    it { subject; expect(client.instance_variable_get(:@cookies)).to eql({ 'JSESSIONID' => '123' }) }
+  end
+
+  describe 'raises error if client not logged in' do
+    subject { client.get_order('any_id') }
+
+    it { expect{subject}.to raise_error(Finale::NotLoggedIn) }
+  end
+
+  describe 'resource methods' do
+    before(:each) do
+      client.login
+    end
+
+    describe '#get_order' do
+      subject { client.get_order('any_id') }
+
+      it { expect{subject}.to_not raise_error }
+      it { is_expected.to be_a(Finale::Order) }
+      it { expect(subject.orderId).to eql('any_id') }
+
+      context 'stubbed response' do
+        before(:each) do
+          client.stub_responses(:get_order, stubbed_response)
+        end
+
+        let(:stubbed_response) { build(:finale_order, options: { id: '123' }) }
+
+        it { expect{subject}.to_not raise_error }
+        it { is_expected.to eql(stubbed_response) }
+      end
+    end
+
+    describe '#get_orders' do
+      subject { client.get_orders() }
+
+      it { expect{subject}.to_not raise_error }
+      it { is_expected.to all(be_a(Finale::Order)) }
+
+      context 'stubbed response' do
+        before(:each) do
+          client.stub_responses(:get_orders, stubbed_response)
+        end
+
+        let(:stubbed_response) { [build(:finale_order, options: { id: '123' })] }
+
+        it { expect{subject}.to_not raise_error }
+        it { is_expected.to eql(stubbed_response) }
+      end
+    end
+
+    describe '#get_shipment' do
+      subject { client.get_shipment('any_id') }
+
+      it { expect{subject}.to_not raise_error }
+      it { is_expected.to be_a(Finale::Shipment) }
+      it { expect(subject.shipmentId).to eql('any_id') }
+
+      context 'stubbed response' do
+        before(:each) do
+          client.stub_responses(:get_shipment, stubbed_response)
+        end
+
+        let(:stubbed_response) { build(:finale_shipment, options: { id: '123' }) }
+
+        it { expect{subject}.to_not raise_error }
+        it { is_expected.to eql(stubbed_response) }
+      end
+    end
+
+    describe '#get_shipments' do
+      subject { client.get_shipments() }
+
+      it { expect{subject}.to_not raise_error }
+      it { is_expected.to all(be_a(Finale::Shipment)) }
+
+      context 'stubbed response' do
+        before(:each) do
+          client.stub_responses(:get_shipments, stubbed_response)
+        end
+
+        let(:stubbed_response) { [build(:finale_shipment, options: { id: '123' })] }
+
+        it { expect{subject}.to_not raise_error }
+        it { is_expected.to eql(stubbed_response) }
+      end
+    end
+
+    describe '#get_shipments_from_order' do
+      subject { client.get_shipments_from_order(order) }
+
+      let(:order) { build(:finale_order) }
+
+      it { expect{subject}.to_not raise_error }
+      it { is_expected.to all(be_a(Finale::Shipment)) }
+      it {
+        shipments = subject
+        order_urls = shipments.map(&:primaryOrderUrl)
+        expect(order_urls).to all(match(/.*#{order.orderId}/))
+      }
+
+      context 'stubbed response' do
+        before(:each) do
+          client.stub_responses(:get_shipments_from_order, stubbed_response)
+        end
+
+        let(:stubbed_response) { [build(:finale_shipment, options: { id: '123' })] }
+
+        it { expect{subject}.to_not raise_error }
+        it { is_expected.to eql(stubbed_response) }
+      end
+    end
+
+    describe '#get_order_from_shipment' do
+      subject { client.get_order_from_shipment(shipment) }
+
+      let(:shipment) { build(:finale_shipment) }
+
+      it { expect{subject}.to_not raise_error }
+      it { is_expected.to be_a(Finale::Order) }
+      it { expect(subject.shipmentUrlList).to include(shipment.shipmentUrl) }
+
+      context 'stubbed response' do
+        before(:each) do
+          client.stub_responses(:get_order_from_shipment, stubbed_response)
+        end
+
+        let(:stubbed_response) { [build(:finale_order, options: { id: '123' })] }
+
+        it { expect{subject}.to_not raise_error }
+        it { is_expected.to eql(stubbed_response) }
+      end
+    end
+
+    describe '#get_facilities' do
+      subject { client.get_facilities() }
+
+      it { expect{subject}.to_not raise_error }
+      it { is_expected.to all(be_a(Finale::Facility)) }
+
+      context 'stubbed response' do
+        before(:each) do
+          client.stub_responses(:get_facilities, stubbed_response)
+        end
+
+        let(:stubbed_response) { [build(:finale_facility, options: { id: '123' })] }
+
+        it { expect{subject}.to_not raise_error }
+        it { is_expected.to eql(stubbed_response) }
+      end
+    end
+
+    describe '#create_shipment_for_order' do
+      subject { client.create_shipment_for_order(order_id, items) }
+
+      let(:order_id) { 'some_id' }
+      let(:item1) { build(:finale_shipment_item, product_id: 'product_1', facility_id: 'facility_1', quantity: 1, lot_id: 'L_F0AAAAA-U0') }
+      let(:item2) { build(:finale_shipment_item, product_id: 'product_2', facility_id: 'facility_1', quantity: 1, lot_id: 'F0BBBBB-U0') }
+      let(:item3) { build(:finale_shipment_item, product_id: 'product_3', facility_id: 'facility_3', quantity: 3, lot_id: nil) }
+      let(:items) { [item1, item2, item3] }
+
+      it { expect{subject}.to_not raise_error }
+      it { is_expected.to be_a(Finale::Shipment) }
+      it {
+        shipment = subject
+        lot_ids = shipment.shipmentItemList.map { |item| item[:lotId] }
+        expect(lot_ids).to contain_exactly('L_F0AAAAA-U0', 'L_F0BBBBB-U0', nil)
+      }
+
+      context 'stubbed response' do
+        before(:each) do
+          client.stub_responses(:create_shipment_for_order, stubbed_response)
+        end
+
+        let(:stubbed_response) { [build(:finale_shipment, options: { id: '123' })] }
+
+        it { expect{subject}.to_not raise_error }
+        it { is_expected.to eql(stubbed_response) }
+      end
+    end
+
+    describe '#pack_shipment' do
+      subject { client.pack_shipment(shipment) }
+
+      let(:shipment) { build(:finale_shipment) }
+
+      it { expect{subject}.to_not raise_error }
+      it { is_expected.to eql(shipment) }
+    end
+  end
+end

--- a/spec/finale/client_spec.rb
+++ b/spec/finale/client_spec.rb
@@ -5,13 +5,6 @@ RSpec.describe Finale::Client do
   let(:client)        { Finale::Client.new(account: 'some_account', throttle_mode: throttle_mode) }
   let(:throttle_mode) { false }
 
-  before(:each) do
-    login_headers  = { 'Set-Cookie' => 'JSESSIONID=some_session_id' }
-    login_response = build(:finale_login_response)
-
-    stub_request(:post, /.*\/auth/).to_return(status: 200, body: login_response.to_json, headers: login_headers)
-  end
-
   describe '#login' do
     subject { client.login(username: username, password: password) }
 

--- a/spec/finale/client_spec.rb
+++ b/spec/finale/client_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Finale::Client do
 
   before(:each) do
     login_headers  = { 'Set-Cookie' => 'JSESSIONID=some_session_id' }
-    login_response = build(:login_response)
+    login_response = build(:finale_login_response)
 
     stub_request(:post, /.*\/auth/).to_return(status: 200, body: login_response.to_json, headers: login_headers)
   end
@@ -57,8 +57,6 @@ RSpec.describe Finale::Client do
         subject
       end
     end
-
-
   end
 
   context '#handle_throttling' do
@@ -110,7 +108,7 @@ RSpec.describe Finale::Client do
       end
 
       let(:order_id) { "12345" }
-      let(:order_response) { build(:order_response, id: order_id) }
+      let(:order_response) { build(:finale_order_response, id: order_id) }
 
       it { expect{subject}.to_not raise_error }
       it { is_expected.to be_a(Finale::Order) }
@@ -123,7 +121,7 @@ RSpec.describe Finale::Client do
         stub_request(:get, /.*\/order/).to_return(status: 200, body: order_collection.to_json)
       end
 
-      let(:order_collection) { build(:order_collection) }
+      let(:order_collection) { build(:finale_order_collection) }
       let(:filter_params) { {} }
 
       it { expect{subject}.to_not raise_error }
@@ -148,7 +146,7 @@ RSpec.describe Finale::Client do
       end
 
       let(:shipment_id) { "12345" }
-      let(:shipment_response) { build(:shipment_response, id: shipment_id) }
+      let(:shipment_response) { build(:finale_shipment_response, id: shipment_id) }
 
       it { expect{subject}.to_not raise_error }
       it { is_expected.to be_a(Finale::Shipment) } end
@@ -161,7 +159,7 @@ RSpec.describe Finale::Client do
         stub_request(:get, /.*\/shipment/).to_return(status: 200, body: shipment_collection.to_json)
       end
 
-      let(:shipment_collection) { build(:shipment_collection) }
+      let(:shipment_collection) { build(:finale_shipment_collection) }
       let(:filter_params) { {} }
 
       it { expect{subject}.to_not raise_error }
@@ -192,10 +190,10 @@ RSpec.describe Finale::Client do
       let(:shipment_id_1) { '11111' }
       let(:shipment_id_2) { '11112' }
 
-      let(:shipment_response_1) { build(:shipment_response, id: shipment_id_1) }
-      let(:shipment_response_2) { build(:shipment_response, id: shipment_id_2) }
+      let(:shipment_response_1) { build(:finale_shipment_response, id: shipment_id_1) }
+      let(:shipment_response_2) { build(:finale_shipment_response, id: shipment_id_2) }
 
-      let(:order) { build(:order, shipment_id1: shipment_id_1, shipment_id2: shipment_id_2) }
+      let(:order) { build(:finale_order, shipment_id1: shipment_id_1, shipment_id2: shipment_id_2) }
 
       it { expect{subject}.to_not raise_error }
       it { is_expected.to be_a(Array) }
@@ -209,8 +207,8 @@ RSpec.describe Finale::Client do
         stub_request(:get, /.*\/order/).to_return(status: 200, body: order.to_json)
       end
 
-      let(:order) { build(:order) }
-      let(:shipment) { build(:shipment, order_id: order.orderId) }
+      let(:order) { build(:finale_order) }
+      let(:shipment) { build(:finale_shipment, order_id: order.orderId) }
 
       it { expect{subject}.to_not raise_error }
       it { is_expected.to be_a(Finale::Order) }
@@ -223,7 +221,7 @@ RSpec.describe Finale::Client do
         stub_request(:get, /.*\/facility/).to_return(status: 200, body: facility_collection.to_json)
       end
 
-      let(:facility_collection) { build(:facility_collection) }
+      let(:facility_collection) { build(:finale_facility_collection) }
 
       it { expect{subject}.to_not raise_error }
       it { is_expected.to all(be_a(Finale::Facility)) }
@@ -237,12 +235,12 @@ RSpec.describe Finale::Client do
       end
 
       let(:order_id) { 'some_id' }
-      let(:item1) { build(:shipment_item, product_id: 'product_1', facility_id: 'facility_1', quantity: 1, lot_id: 'L_F0AAAAA-U0') }
-      let(:item2) { build(:shipment_item, product_id: 'product_2', facility_id: 'facility_1', quantity: 1, lot_id: 'F0BBBBB-U0') }
-      let(:item3) { build(:shipment_item, product_id: 'product_3', facility_id: 'facility_3', quantity: 3) }
+      let(:item1) { build(:finale_shipment_item, product_id: 'product_1', facility_id: 'facility_1', quantity: 1, lot_id: 'L_F0AAAAA-U0') }
+      let(:item2) { build(:finale_shipment_item, product_id: 'product_2', facility_id: 'facility_1', quantity: 1, lot_id: 'F0BBBBB-U0') }
+      let(:item3) { build(:finale_shipment_item, product_id: 'product_3', facility_id: 'facility_3', quantity: 3, lot_id: nil) }
       let(:items) { [item1, item2, item3] }
 
-      let(:response) { build(:shipment_response) }
+      let(:response) { build(:finale_shipment_response) }
 
       it { expect{subject}.to_not raise_error }
       it { is_expected.to be_a(Finale::Shipment) }
@@ -255,7 +253,7 @@ RSpec.describe Finale::Client do
         stub_request(:post, /.*\/shipment\/.*\/pack/).to_return(status: 200, body: shipment.to_json)
       end
 
-      let(:shipment) { build(:shipment) }
+      let(:shipment) { build(:finale_shipment) }
 
       it { expect{subject}.to_not raise_error }
       it { is_expected.to be_a(Finale::Shipment) }

--- a/spec/finale/order_spec.rb
+++ b/spec/finale/order_spec.rb
@@ -1,24 +1,27 @@
 require 'spec_helper'
 
 RSpec.describe Finale::Order do
-  let(:order_response) { build(:order_response) }
-
-  describe '#initialize' do
+  describe '#initialize from an order_response' do
     subject { Finale::Order.new(order_response) }
 
+    let(:order_response) { build(:finale_order_response) }
+
     it { expect{subject}.to_not raise_error }
+    it { expect(subject.orderId).to be_a(String) }
+    it { expect(subject.saleSourceId).to be_a(String) }
+    it { expect(subject.shipmentUrlList).to be_an(Array) }
+  end
 
-    it 'should have an id' do
-      expect(subject.orderId).to be_an(String)
-    end
+  describe 'using the factory' do
+    subject { build(:finale_order) }
 
-    it 'should have a source' do
-      expect(subject.saleSourceId).to be_a(String)
-    end
+    it { is_expected.to be_a(Finale::Order) }
 
-    it 'should have shipment_urls' do
-      expect(subject.shipmentUrlList).to be_an(Array)
+    context 'specifying values' do
+      subject { build(:finale_order, options: { saleSourceId: 'My Store' }) }
+
+      it { expect(subject.saleSourceId).to eql('My Store') }
+      it { is_expected.to be_a(Finale::Order) }
     end
   end
 end
-

--- a/spec/finale/shipment_item_spec.rb
+++ b/spec/finale/shipment_item_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.describe Finale::ShipmentItem do
+  describe '#format_for_post' do
+    subject { shipment_item.format_for_post('account') }
+
+    let(:shipment_item) { Finale::ShipmentItem.new(product_id: product_id, facility_id: facility_id, quantity: quantity, lot_id: lot_id) }
+    let(:product_id) { 'product_1' }
+    let(:facility_id) { 'facility_1' }
+    let(:quantity) { 1 }
+    let(:lot_id) { 'L_F0AAAAA-U0' }
+
+    let(:expected) {
+      {
+        productUrl: 'account/api/product/product_1',
+        facilityUrl: 'account/api/facility/facility_1',
+        quantity: 1,
+        lotId: 'L_F0AAAAA-U0'
+      }
+    }
+
+    it { is_expected.to eql(expected) }
+
+    context 'lot_id without the prefix' do
+      let(:lot_id) { 'F0AAAAA-U0' }
+
+      it { is_expected.to eql(expected) }
+    end
+
+    context 'lot_id without the prefix' do
+      let(:lot_id) { nil }
+      let(:expected) {
+        {
+          productUrl: 'account/api/product/product_1',
+          facilityUrl: 'account/api/facility/facility_1',
+          quantity: 1
+        }
+      }
+
+      it { is_expected.to eql(expected) }
+    end
+  end
+end

--- a/spec/finale/shipment_item_spec.rb
+++ b/spec/finale/shipment_item_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Finale::ShipmentItem do
     let(:expected) {
       {
         productUrl: 'account/api/product/product_1',
-        facilityUrl: 'account/api/facility/facility_1',
+        facilityUrl: '/account/api/facility/facility_1',
         quantity: 1,
         lotId: 'L_F0AAAAA-U0'
       }
@@ -32,7 +32,7 @@ RSpec.describe Finale::ShipmentItem do
       let(:expected) {
         {
           productUrl: 'account/api/product/product_1',
-          facilityUrl: 'account/api/facility/facility_1',
+          facilityUrl: '/account/api/facility/facility_1',
           quantity: 1
         }
       }

--- a/spec/finale/shipment_spec.rb
+++ b/spec/finale/shipment_spec.rb
@@ -1,49 +1,53 @@
 require 'spec_helper'
 
 RSpec.describe Finale::Shipment do
-  describe '#initialize' do
+  describe '#initialize from shipment_response' do
     subject { Finale::Shipment.new(shipment_response) }
 
-    let(:shipment_response) { build(:shipment_response) }
+    let(:shipment_response) { build(:finale_shipment_response) }
 
     it { expect{subject}.to_not raise_error }
   end
 
-  describe '#lot_ids' do
-    subject { shipment.lot_ids }
-
-    let(:lot_id1) { 'some_lot_id_1' }
-    let(:lot_id2) { 'some_lot_id_2' }
-    let(:shipment_response) { build(:shipment_response, lot_id1: lot_id1, lot_id2: lot_id2) }
-    let(:shipment) { Finale::Shipment.new(shipment_response) }
+  describe 'using the factory' do
+    subject { build(:finale_shipment) }
 
     it { expect{subject}.to_not raise_error }
-    it { expect(subject).to include(lot_id1, lot_id2) }
+    it { is_expected.to be_a(Finale::Shipment) }
 
-    context 'empty lot id compacts' do
-      let(:lot_id2) { nil }
+    describe '#lot_ids' do
+      subject { shipment.lot_ids }
 
-      it { expect{subject}.to_not raise_error }
-      it { expect(subject).to eq([lot_id1]) }
-    end
-
-    context 'empty shipment item list' do
-      let(:shipment_response) { build(:shipment_response, shipment_item_list: nil) }
+      let(:lot_id1) { 'some_lot_id_1' }
+      let(:lot_id2) { 'some_lot_id_2' }
+      let(:shipment) { build(:finale_shipment, options: { lot_id1: lot_id1, lot_id2: lot_id2 }) }
 
       it { expect{subject}.to_not raise_error }
-      it { expect(subject).to eq([]) }
+      it { expect(subject).to include(lot_id1, lot_id2) }
+
+      context 'empty lot id compacts' do
+        let(:lot_id2) { nil }
+
+        it { expect{subject}.to_not raise_error }
+        it { expect(subject).to eq([lot_id1]) }
+      end
+
+      context 'empty shipment item list' do
+        let(:shipment) { build(:finale_shipment, options: { shipment_item_list: nil}) }
+
+        it { expect{subject}.to_not raise_error }
+        it { expect(subject).to eq([]) }
+      end
     end
-  end
 
-  describe '#order_id' do
-    subject { shipment.order_id }
+    describe '#order_id' do
+      subject { shipment.order_id }
 
-    let(:order_id) { 'some_order_id' }
-    let(:shipment_response) { build(:shipment_response, order_id: order_id) }
-    let(:shipment) { Finale::Shipment.new(shipment_response) }
+      let(:order_id) { 'some_order_id' }
+      let(:shipment) { build(:finale_shipment, options: { order_id: order_id }) }
 
-    it { expect{subject}.to_not raise_error }
-    it { expect(subject).to eq(order_id) }
+      it { expect{subject}.to_not raise_error }
+      it { expect(subject).to eq(order_id) }
+    end
   end
 end
-

--- a/spec/finale/uri_helper_spec.rb
+++ b/spec/finale/uri_helper_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+RSpec.describe Finale::URIHelper do
+  let(:klass) { Finale::Client.new(account: 'some_account') }
+  let(:base) { Finale::URIHelper.const_get(:BASE_URL) }
+
+  describe '#url' do
+    context 'for resource' do
+      subject { klass.url(:shipments) }
+
+      let(:expected) { "#{base}/some_account/api/shipments" }
+
+      it { is_expected.to eq(expected) }
+
+      context 'by id' do
+        subject { klass.url(:shipments, id: 11) }
+
+        let(:expected) { "#{base}/some_account/api/shipments/11" }
+
+        it { is_expected.to eq(expected) }
+
+        context 'with action' do
+          subject { klass.url(:shipments, id: 11, action: :pack) }
+
+          let(:expected) { "#{base}/some_account/api/shipments/11/pack" }
+
+          it { is_expected.to eq(expected) }
+        end
+      end
+    end
+
+    context 'overriding url_base' do
+      subject { klass.url(:shipments, url_base: 'http://other_domain') }
+
+      let(:expected) { 'http://other_domain/some_account/api/shipments' }
+
+      it { is_expected.to eq(expected) }
+    end
+
+    context 'overriding account' do
+      subject { klass.url(:shipments, account: 'other_account') }
+
+      let(:expected) { "#{base}/other_account/api/shipments" }
+
+      it { is_expected.to eq(expected) }
+    end
+  end
+
+  describe '#url_from_path' do
+    subject { klass.url_from_path('a/resource/path') }
+
+    let(:expected) { "#{base}/a/resource/path" }
+
+    it { is_expected.to eq(expected) }
+
+    context 'overriding url_base' do
+      subject { klass.url_from_path('a/resource/path', url_base: 'http://other_domain') }
+
+      let(:expected) { 'http://other_domain/a/resource/path' }
+
+      it { is_expected.to eq(expected) }
+    end
+  end
+
+  describe '#resource_path' do
+    context 'for resource' do
+      subject { klass.resource_path(:shipments) }
+
+      let(:expected) { 'some_account/api/shipments' }
+
+      it { is_expected.to eq(expected) }
+
+      context 'by id' do
+        subject { klass.resource_path(:shipments, id: 11) }
+
+        let(:expected) { 'some_account/api/shipments/11' }
+
+        it { is_expected.to eq(expected) }
+
+        context 'with action' do
+          subject { klass.resource_path(:shipments, id: 11, action: :pack) }
+
+          let(:expected) { 'some_account/api/shipments/11/pack' }
+
+          it { is_expected.to eq(expected) }
+        end
+      end
+    end
+
+    context 'overriding account' do
+      subject { klass.resource_path(:shipments, account: 'other_account') }
+
+      let(:expected) { 'other_account/api/shipments' }
+
+      it { is_expected.to eq(expected) }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,4 +21,11 @@ require 'finale'
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   FactoryBot.find_definitions
+
+  config.before(:each) do
+    login_headers  = { 'Set-Cookie' => 'JSESSIONID=some_session_id' }
+    login_response = build(:finale_login_response)
+
+    stub_request(:post, /.*\/auth/).to_return(status: 200, body: login_response.to_json, headers: login_headers)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,18 @@
-require "bundler/setup"
-require "factory_bot"
-require "webmock/rspec"
-require "simplecov"
-require 'pry'
-
-require "finale"
+require 'simplecov'
 
 SimpleCov.start do
   add_filter 'spec'
+  enable_coverage :branch
 end
+
+require 'bundler/setup'
+require 'factory_bot'
+require 'webmock/rspec'
+require 'pry'
+
+require 'finale'
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   FactoryBot.find_definitions
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,13 @@
 require 'simplecov'
 
 SimpleCov.start do
-  add_filter 'spec'
+  add_filter do |source_file|
+    if (source_file.filename.match? 'client_mock.rb')
+      false
+    else
+      source_file.filename.match? '/spec/'
+    end
+  end
   enable_coverage :branch
 end
 

--- a/spec/test_support.rb
+++ b/spec/test_support.rb
@@ -1,0 +1,11 @@
+require 'factory_bot'
+
+module Finale
+  class TestSupport
+    def self.load_definitions
+      FactoryBot.definition_file_paths ||= []
+      # Unshift ensures these factories are defined prior to yours, allowing you to FactoryBot.modify them.
+      FactoryBot.definition_file_paths.unshift(Finale.root.join('spec', 'factories'))
+    end
+  end
+end

--- a/spec/test_support.rb
+++ b/spec/test_support.rb
@@ -1,5 +1,3 @@
-require 'factory_bot'
-
 module Finale
   class TestSupport
     def self.load_definitions


### PR DESCRIPTION
Add leading slash for facility url only. Finale changed the validation on this url along with 2 others we don't use.

From Finale:
```
Finale Inventory has updated the validations for the shipment this week. We have added validations for:
  1. the shipment items' facilityUrl parameter
  2. the shipment's destinationFacilityUrl, and originFacilityUrl

Turns out the facilityUrl you're sending notion/api/facility/10031 is missing a / at the beginning, so it should be like /notion/api/facility/10031.
```